### PR TITLE
add Dockerfile to support OpenROAD unified build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,109 @@
+.git
+.dockerignore
+Dockerfile
+
+# from .gitignore
+*.def
+*.lef
+
+build
+ioPlacer
+
+tags
+
+**/nbproject/private/
+**/nbproject/Makefile-*.mk
+**/nbproject/Package-*.bash
+build/
+nbbuild/
+dist/
+nbdist/
+.nb-gradle/
+nbproject/
+
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps
+
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+FROM centos:centos6 AS builder
+
+# install gcc 6
+RUN yum -y install centos-release-scl && \
+    yum -y install devtoolset-6 devtoolset-6-libatomic-devel
+ENV CC=/opt/rh/devtoolset-6/root/usr/bin/gcc \
+    CPP=/opt/rh/devtoolset-6/root/usr/bin/cpp \
+    CXX=/opt/rh/devtoolset-6/root/usr/bin/g++ \
+    PATH=/opt/rh/devtoolset-6/root/usr/bin:$PATH \
+    LD_LIBRARY_PATH=/opt/rh/devtoolset-6/root/usr/lib64:/opt/rh/devtoolset-6/root/usr/lib:/opt/rh/devtoolset-6/root/usr/lib64/dyninst:/opt/rh/devtoolset-6/root/usr/lib/dyninst:/opt/rh/devtoolset-6/root/usr/lib64:/opt/rh/devtoolset-6/root/usr/lib:$LD_LIBRARY_PATH
+
+# Common development tools and libraries (kitchen sink approach)
+RUN yum groupinstall -y "Development Tools" "Development Libraries"
+
+RUN yum install -y wget rh-mongodb32-boost-devel rh-mongodb32-boost-static
+ENV PATH=/opt/rh/rh-mongodb32/root/usr/bin:$PATH \
+    LD_LIBRARY_PATH=/opt/rh/rh-mongodb32/root/usr/lib64:/opt/rh/rh-mongodb32/root/usr/lib:/opt/rh/rh-mongodb32/root/usr/lib64/dyninst:/opt/rh/rh-mongodb32/root/usr/lib/dyninst:/opt/rh/rh-mongodb32/root/usr/lib64:/opt/rh/rh-mongodb32/root/usr/lib:$LD_LIBRARY_PATH \
+    C_INCLUDE_PATH=/opt/rh/rh-mongodb32/root/usr/include \
+    CPLUS_INCLUDE_PATH=/opt/rh/rh-mongodb32/root/usr/include
+
+RUN wget https://cmake.org/files/v3.9/cmake-3.9.0-Linux-x86_64.sh && \
+    chmod +x cmake-3.9.0-Linux-x86_64.sh  && \
+    ./cmake-3.9.0-Linux-x86_64.sh --skip-license --prefix=/usr/local
+
+RUN yum install -y zlib-devel
+
+COPY . /ioPlacer
+RUN mkdir /ioPlacer/build
+WORKDIR /ioPlacer/build
+RUN cmake -DCMAKE_BUILD_TYPE=Release -DBOOST_ROOT=/opt/rh/rh-mongodb32/root/usr ..  && \
+    make
+
+# run time environment
+FROM centos:centos6 AS runner
+RUN yum update -y && yum install -y tcl-devel libgomp
+COPY --from=builder /ioPlacer/build/ioPlacer /build/ioPlacer
+COPY --from=builder /ioPlacer/scripts/replace_ioplace_loop.sh /build/replace_ioplace_loop.sh
+RUN useradd -ms /bin/bash openroad
+USER openroad
+WORKDIR /home/openroad


### PR DESCRIPTION
This pull request adds a Dockerfile to the repository to integrate in the unified build environment. The image is based on centos6, which is the agreed build environment for OpenROAD.

To build:
`docker build -t <image_name> .`

Binaries are in `/build` directory, which can also be run from within the container.