### PR TITLE
modified the test_no_tracks testcase to really have no tracks

### DIFF
--- a/test/src/test_no_tracks/ioPlacer.tcl
+++ b/test/src/test_no_tracks/ioPlacer.tcl
@@ -7,4 +7,4 @@ read_sdc ./gcd.sdc
 initialize_floorplan -site FreePDK45_38x28_10R_NP_162NW_34O \
 -utilization 30
 
-io_placer -random -hor_layer 3 -ver_layer 2
+io_placer -random -hor_layer 2 -ver_layer 3


### PR DESCRIPTION
So, as far as I can see, the `test_no_tracks` testcase is about what happens when ioPlacer attempts to place pins while there aren't tracks for it. However, as the techLEF specifies, metal3 and metal2 are horizontal and vertical, respectively, so this testcase was not supposed to "successfully" fail in the first place. It did so far due to a minor bug in init_fp when no tracks_file is provided.

I have swapped the horizontal and vertical layers here so that it reports the "no tracks structure" error when init_fp is [fixed](https://github.com/The-OpenROAD-Project/OpenROAD/pull/261).  The CI will initially complain about this testcase failing, but this change needs to be merged first so I can go ahead and update the ioPlacer submodule pointer for https://github.com/The-OpenROAD-Project/OpenROAD/pull/249 (now https://github.com/The-OpenROAD-Project/OpenROAD/pull/261) to pass.

Please let me know your feedback on that.
Thanks.